### PR TITLE
WP-002: Form Executor Implementation

### DIFF
--- a/app/executors/form.py
+++ b/app/executors/form.py
@@ -1,0 +1,75 @@
+"""Form step executor for collecting user inputs."""
+
+from typing import Any
+
+from app.models.schemas import FormStepConfig
+
+
+class FormExecutor:
+    """Executes form steps to collect user input with field validation."""
+
+    def __init__(self, config: FormStepConfig):
+        """Initialize form executor with step configuration.
+
+        Args:
+            config: Form step configuration containing field definitions
+        """
+        self.config = config
+
+    def validate_fields(self, inputs: dict[str, Any]) -> dict[str, Any]:
+        """Validate form inputs against field schema.
+
+        Args:
+            inputs: User-provided input values
+
+        Returns:
+            Validated inputs
+
+        Raises:
+            ValueError: If validation fails (missing required field, invalid type, unsupported field type)
+        """
+        validated = {}
+
+        for field in self.config.fields:
+            # Check if required field is missing
+            if field.required and field.key not in inputs:
+                raise ValueError(f"Required field '{field.key}' is missing")
+
+            # Skip optional missing fields
+            if field.key not in inputs:
+                continue
+
+            # Validate field type (text/textarea only for MVID)
+            if field.type not in ("text", "textarea"):
+                raise ValueError(
+                    f"Field type '{field.type}' not supported. Only 'text' and 'textarea' are allowed."
+                )
+
+            # Validate value is string
+            value = inputs[field.key]
+            if not isinstance(value, str):
+                raise ValueError(f"Field '{field.key}' must be a string")
+
+            validated[field.key] = value
+
+        return validated
+
+    async def execute(self, context: dict[str, Any], step_id: str) -> dict[str, Any]:
+        """Execute form step by pausing workflow and storing field schema.
+
+        Args:
+            context: Current workflow execution context
+            step_id: ID of the current step
+
+        Returns:
+            Execution result with pause signal and field schema
+        """
+        # Store field schema in context for resume validation
+        context["runtime"][f"{step_id}_schema"] = self.config.model_dump()["fields"]
+
+        # Return pause signal to engine
+        return {
+            "pause": True,
+            "waiting_for": "form",
+            "fields_schema": self.config.model_dump()["fields"],
+        }

--- a/app/executors/form.py
+++ b/app/executors/form.py
@@ -26,7 +26,8 @@ class FormExecutor:
             Validated inputs
 
         Raises:
-            ValueError: If validation fails (missing required field, invalid type, unsupported field type)
+            ValueError: If validation fails (missing required field, invalid type,
+                unsupported field type)
         """
         validated = {}
 
@@ -42,7 +43,8 @@ class FormExecutor:
             # Validate field type (text/textarea only for MVID)
             if field.type not in ("text", "textarea"):
                 raise ValueError(
-                    f"Field type '{field.type}' not supported. Only 'text' and 'textarea' are allowed."
+                    f"Field type '{field.type}' not supported. "
+                    "Only 'text' and 'textarea' are allowed."
                 )
 
             # Validate value is string

--- a/tests/unit/executors/test_form.py
+++ b/tests/unit/executors/test_form.py
@@ -1,0 +1,233 @@
+"""Unit tests for FormExecutor."""
+
+import pytest
+
+from app.executors.form import FormExecutor
+from app.models.schemas import FormStepConfig, StepConfigField
+
+
+class TestFormExecutorValidateFields:
+    """Tests for FormExecutor.validate_fields()"""
+
+    def test_validate_fields_success_all_required(self):
+        """Given all required fields, When validate_fields called, Then passes."""
+        config = FormStepConfig(
+            fields=[
+                StepConfigField(key="name", type="text", required=True),
+                StepConfigField(key="email", type="text", required=True),
+            ]
+        )
+        executor = FormExecutor(config)
+
+        inputs = {"name": "John Doe", "email": "john@example.com"}
+        validated = executor.validate_fields(inputs)
+
+        assert validated == inputs
+
+    def test_validate_fields_success_with_optional(self):
+        """Given optional field omitted, When validate_fields called, Then passes
+        without optional field."""
+        config = FormStepConfig(
+            fields=[
+                StepConfigField(key="name", type="text", required=True),
+                StepConfigField(key="notes", type="textarea", required=False),
+            ]
+        )
+        executor = FormExecutor(config)
+
+        inputs = {"name": "John Doe"}
+        validated = executor.validate_fields(inputs)
+
+        assert validated == {"name": "John Doe"}
+        assert "notes" not in validated
+
+    def test_validate_fields_success_optional_provided(self):
+        """Given optional field provided, When validate_fields called,
+        Then includes optional field."""
+        config = FormStepConfig(
+            fields=[
+                StepConfigField(key="name", type="text", required=True),
+                StepConfigField(key="notes", type="textarea", required=False),
+            ]
+        )
+        executor = FormExecutor(config)
+
+        inputs = {"name": "John Doe", "notes": "Some notes"}
+        validated = executor.validate_fields(inputs)
+
+        assert validated == inputs
+
+    def test_validate_fields_missing_required_raises_error(self):
+        """Given required field missing, When validate_fields called, Then ValueError raised."""
+        config = FormStepConfig(
+            fields=[
+                StepConfigField(key="name", type="text", required=True),
+                StepConfigField(key="email", type="text", required=True),
+            ]
+        )
+        executor = FormExecutor(config)
+
+        inputs = {"name": "John Doe"}  # missing email
+
+        with pytest.raises(ValueError, match="Required field 'email' is missing"):
+            executor.validate_fields(inputs)
+
+    def test_validate_fields_unsupported_type_raises_error(self):
+        """Given unsupported field type, When validate_fields called, Then ValueError raised."""
+        config = FormStepConfig(
+            fields=[
+                StepConfigField(key="age", type="number", required=True),  # unsupported in MVID
+            ]
+        )
+        executor = FormExecutor(config)
+
+        inputs = {"age": "25"}
+
+        with pytest.raises(
+            ValueError,
+            match="Field type 'number' not supported. Only 'text' and 'textarea' are allowed.",
+        ):
+            executor.validate_fields(inputs)
+
+    def test_validate_fields_non_string_value_raises_error(self):
+        """Given non-string value, When validate_fields called, Then ValueError raised."""
+        config = FormStepConfig(
+            fields=[
+                StepConfigField(key="name", type="text", required=True),
+            ]
+        )
+        executor = FormExecutor(config)
+
+        inputs = {"name": 12345}  # number instead of string
+
+        with pytest.raises(ValueError, match="Field 'name' must be a string"):
+            executor.validate_fields(inputs)
+
+    def test_validate_fields_empty_string_allowed(self):
+        """Given empty string for required field, When validate_fields called,
+        Then passes."""
+        config = FormStepConfig(
+            fields=[
+                StepConfigField(key="name", type="text", required=True),
+            ]
+        )
+        executor = FormExecutor(config)
+
+        inputs = {"name": ""}
+        validated = executor.validate_fields(inputs)
+
+        assert validated == {"name": ""}
+
+    def test_validate_fields_textarea_type_allowed(self):
+        """Given textarea field type, When validate_fields called, Then validation passes."""
+        config = FormStepConfig(
+            fields=[
+                StepConfigField(key="description", type="textarea", required=True),
+            ]
+        )
+        executor = FormExecutor(config)
+
+        inputs = {"description": "Long text content\nwith multiple lines"}
+        validated = executor.validate_fields(inputs)
+
+        assert validated == inputs
+
+    def test_validate_fields_extra_fields_ignored(self):
+        """Given extra fields not in schema, When validate_fields called,
+        Then extra fields ignored."""
+        config = FormStepConfig(
+            fields=[
+                StepConfigField(key="name", type="text", required=True),
+            ]
+        )
+        executor = FormExecutor(config)
+
+        inputs = {"name": "John Doe", "extra_field": "ignored"}
+        validated = executor.validate_fields(inputs)
+
+        assert validated == {"name": "John Doe"}
+        assert "extra_field" not in validated
+
+
+class TestFormExecutorExecute:
+    """Tests for FormExecutor.execute()"""
+
+    @pytest.mark.asyncio
+    async def test_execute_returns_pause_signal(self):
+        """Given form config, When execute called, Then pause signal returned."""
+        config = FormStepConfig(
+            fields=[
+                StepConfigField(key="name", type="text", required=True),
+            ]
+        )
+        executor = FormExecutor(config)
+
+        context = {"static": {}, "profile": {}, "runtime": {}}
+        result = await executor.execute(context, step_id="step_1")
+
+        assert result["pause"] is True
+        assert result["waiting_for"] == "form"
+        assert "fields_schema" in result
+
+    @pytest.mark.asyncio
+    async def test_execute_stores_schema_in_context(self):
+        """Given form config, When execute called, Then field schema stored in context."""
+        config = FormStepConfig(
+            fields=[
+                StepConfigField(key="name", type="text", required=True),
+                StepConfigField(key="email", type="text", required=True),
+            ]
+        )
+        executor = FormExecutor(config)
+
+        context = {"static": {}, "profile": {}, "runtime": {}}
+        await executor.execute(context, step_id="step_1")
+
+        assert "step_1_schema" in context["runtime"]
+        schema = context["runtime"]["step_1_schema"]
+        assert len(schema) == 2
+        assert schema[0]["key"] == "name"
+        assert schema[1]["key"] == "email"
+
+    @pytest.mark.asyncio
+    async def test_execute_returns_correct_fields_schema(self):
+        """Given form config, When execute called, Then fields_schema matches config."""
+        config = FormStepConfig(
+            fields=[
+                StepConfigField(key="username", type="text", required=True),
+                StepConfigField(key="bio", type="textarea", required=False),
+            ]
+        )
+        executor = FormExecutor(config)
+
+        context = {"static": {}, "profile": {}, "runtime": {}}
+        result = await executor.execute(context, step_id="step_2")
+
+        fields_schema = result["fields_schema"]
+        assert len(fields_schema) == 2
+        assert fields_schema[0]["key"] == "username"
+        assert fields_schema[0]["type"] == "text"
+        assert fields_schema[0]["required"] is True
+        assert fields_schema[1]["key"] == "bio"
+        assert fields_schema[1]["type"] == "textarea"
+        assert fields_schema[1]["required"] is False
+
+    @pytest.mark.asyncio
+    async def test_execute_preserves_existing_runtime_context(self):
+        """Given existing runtime context, When execute called, Then existing context preserved."""
+        config = FormStepConfig(
+            fields=[
+                StepConfigField(key="name", type="text", required=True),
+            ]
+        )
+        executor = FormExecutor(config)
+
+        context = {
+            "static": {},
+            "profile": {},
+            "runtime": {"previous_step_data": "preserved"},
+        }
+        await executor.execute(context, step_id="step_3")
+
+        assert context["runtime"]["previous_step_data"] == "preserved"
+        assert "step_3_schema" in context["runtime"]


### PR DESCRIPTION
## Work Package: WP-002 - Form Executor

**Status**: ✅ Complete and ready for review  
**Duration**: 3 hours  
**Priority**: P0  
**Type**: Feature

### Deliverables
- ✅ FormExecutor class with validate_fields() and execute()
- ✅ Support for text/textarea field types (MVID scope)
- ✅ Required field validation
- ✅ Type checking and error handling
- ✅ Comprehensive unit tests (13 test cases)
- ✅ 100% code coverage for FormExecutor

### Implementation Details

**Core Functionality:**
- `validate_fields()` - Validates user inputs against field schema
  - Checks required fields are present
  - Validates field types (text/textarea only for MVID)
  - Ensures values are strings
  - Returns validated input dict
  
- `execute()` - Executes form step by pausing workflow
  - Stores field schema in context for resume validation
  - Returns pause signal with `waiting_for: "form"`
  - Includes field schema in response

**Error Handling:**
- Raises `ValueError` for missing required fields
- Raises `ValueError` for unsupported field types
- Raises `ValueError` for non-string values

### Test Coverage

**13 comprehensive test cases covering:**
- ✅ All validation scenarios (required, optional, types)
- ✅ Execute pause signal and context storage
- ✅ Edge cases (empty strings, extra fields)
- ✅ Error conditions with proper exception messages

**Coverage**: 100% for app.executors.form

### Quality Checks
- ✅ All tests passing (13/13)
- ✅ Ruff linting passed
- ✅ MyPy type checking passed
- ✅ 100% code coverage achieved

### Files Changed
- `app/executors/form.py` (77 lines) - Implementation
- `tests/unit/executors/test_form.py` (233 lines) - Tests

Fixes #2